### PR TITLE
use the max-body from edgerc or from optional argument passed to Edge…

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,5 @@
 // Copyright 2014 Akamai Technologies, Inc. All Rights Reserved
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,12 +20,12 @@ var request = require('request'),
     helpers = require('./helpers'),
     logger = require('./logger');
 
-var EdgeGrid = function(client_token, client_secret, access_token, host) {
+var EdgeGrid = function(client_token, client_secret, access_token, host, max_body) {
   // accepting an object containing a path to .edgerc and a config section
   if (typeof arguments[0] === 'object') {
     this._setConfigFromObj(arguments[0]);
   } else {
-    this._setConfigFromStrings(client_token, client_secret, access_token, host);
+    this._setConfigFromStrings(client_token, client_secret, access_token, host, max_body);
   }
 };
 
@@ -40,7 +40,7 @@ EdgeGrid.prototype.auth = function(req) {
     body: {}
   });
 
-  this.request = auth.generate_auth(req, this.config.client_token, this.config.client_secret, this.config.access_token, this.config.host);
+  this.request = auth.generate_auth(req, this.config.client_token, this.config.client_secret, this.config.access_token, this.config.host, null, this.config.max_body);
 };
 
 EdgeGrid.prototype.send = function(callback) {
@@ -80,7 +80,7 @@ EdgeGrid.prototype._setConfigFromObj = function(obj) {
   this.config = edgerc(obj.path, obj.section);
 };
 
-EdgeGrid.prototype._setConfigFromStrings = function(client_token, client_secret, access_token, host) {
+EdgeGrid.prototype._setConfigFromStrings = function(client_token, client_secret, access_token, host, max_body) {
   if (!validatedArgs([client_token, client_secret, access_token, host])) {
     throw new Error('Insufficient Akamai credentials');
   }
@@ -89,7 +89,8 @@ EdgeGrid.prototype._setConfigFromStrings = function(client_token, client_secret,
     client_token: client_token,
     client_secret: client_secret,
     access_token: access_token,
-    host: host.indexOf('https://') > -1 ? host : 'https://' + host
+    host: host.indexOf('https://') > -1 ? host : 'https://' + host,
+    max_body : max_body || 2048
   };
 };
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,5 +1,5 @@
 // Copyright 2014 Akamai Technologies, Inc. All Rights Reserved
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -150,7 +150,7 @@ var make_auth_header = function(request, client_token, access_token, client_secr
 };
 
 module.exports = {
-    generate_auth: function(request, client_token, client_secret, access_token, host, headers_to_sign, max_body, guid, timestamp) {
+  generate_auth: function(request, client_token, client_secret, access_token, host, headers_to_sign, max_body, guid, timestamp) {
 
         _max_body = max_body || 2048;
         _headers_to_sign = headers_to_sign || [];

--- a/src/edgerc.js
+++ b/src/edgerc.js
@@ -1,5 +1,5 @@
 // Copyright 2014 Akamai Technologies, Inc. All Rights Reserved
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -23,7 +23,7 @@ function getSection(lines, sectionName) {
         lineMatch = line.match(match);
 
         if (lineMatch && lineMatch[1] === sectionName) {
-            section = lines.slice(i + 1, i + 5);
+            section = lines.slice(i + 1, i + 6);
         }
     });
 
@@ -37,7 +37,6 @@ function validatedConfig(config) {
 
     config.host = 'https://' + config.host;
 
-    console.log("Config: ", config);
     return config;
 }
 
@@ -46,12 +45,13 @@ function buildObj(configs) {
         keyVal;
 
     configs.forEach(function(config) {
-        // Break string apart at first occurance of equal sign 
+        // Break string apart at first occurance of equal sign
         // character in case the character is found in the value
         // strings.
         var index = config.indexOf('='),
-            key = config.substr(0, index)
-        val = config.substr(index + 1, config.length - index - 1);
+            rawkey = config.substr(0, index),
+            key = rawkey.replace('-','_'),
+            val = config.substr(index + 1, config.length - index - 1);
 
         result[key.trim()] = val.trim();
     });
@@ -63,10 +63,12 @@ module.exports = function(path, conf) {
     var edgerc = fs.readFileSync(path).toString().split("\n"),
         confSection = conf || 'default',
         confData = getSection(edgerc, confSection);
-
     if (!confData) {
         throw new Error('An error occurred parsing the .edgerc file. You probably specified an invalid section name.');
     }
-
-    return buildObj(confData);
+    var configObject = buildObj(confData);
+    if (!configObject) {
+        throw new Error('An error occurred parsing the .edgerc file. You probably have invalid data within a section.');
+    }
+    return configObject;
 };

--- a/test/src/api_test.js
+++ b/test/src/api_test.js
@@ -1,5 +1,5 @@
 // Copyright 2014 Akamai Technologies, Inc. All Rights Reserved
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -23,7 +23,8 @@ describe('Api', function() {
             'clientToken',
             'clientSecret',
             'accessToken',
-            'base.com'
+            'base.com',
+            1000
         );
     });
 
@@ -42,6 +43,10 @@ describe('Api', function() {
 
         it('reports the API host', function() {
             assert.equal(this.api.config.host, 'https://base.com');
+        });
+
+        it('reports the max body', function() {
+            assert.equal(this.api.config.max_body, 1000);
         });
 
         describe('when it is instantiated with an API host that already contains the protocol', function() {
@@ -81,6 +86,10 @@ describe('Api', function() {
                 assert.equal(this.api.config.host, 'https://sectionexample.luna.akamaiapis.net');
             });
 
+            it('reports the max-body from the edgerc associated with the specified section', function() {
+                assert.equal(this.api.config.max_body, 131072);
+            });
+
             describe('when it is instantiated with an object that does not specfy a section', function() {
                 beforeEach(function() {
                     this.api = new Api({
@@ -102,6 +111,9 @@ describe('Api', function() {
 
                 it('reports the API host from the edgerc associated with the default section', function() {
                     assert.equal(this.api.config.host, 'https://example.luna.akamaiapis.net');
+                });
+                it('reports the max-body from the edgerc associated with the default section', function() {
+                    assert.equal(this.api.config.max_body, 131072);
                 });
             });
 

--- a/test/test.js
+++ b/test/test.js
@@ -53,6 +53,21 @@ describe('Signature Generation', function() {
         });
     });
 
+    describe('Post uses passed-max-body', function() {
+        it('should return the expected string when the signing request is run.', function() {
+            var expected_header = "EG1-HMAC-SHA256 client_token=akab-client-token-xxx-xxxxxxxxxxxxxxxx;access_token=akab-access-token-xxx-xxxxxxxxxxxxxxxx;timestamp=20140321T19:34:21+0000;nonce=nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;signature=asJgKWm9tB/YhFByqnOtpcgvmzR+zpTGBgaSY/IhbNA=";
+            var data = "datadatadatadatadatadatadatadata";
+            var request = {
+                //"url": "https://akaa-kax6r2oleojomqr3-q2i5ed3v35xfwe3j.luna.akamaiapis.net/billing-usage/v1/contractusagedata/contract/C-6JGLXF/6/2014",
+                "path": "testapi/v1/t3",
+                "method": "POST",
+                "body": data
+            };
+            test_auth = auth.generate_auth(request, client_token, client_secret, access_token, base_url, false, 10, nonce, timestamp);
+            assert.equal(test_auth.headers.Authorization, expected_header);
+        });
+    });
+
     describe('POST too large', function() {
         it('should return the expected string when the signing request is run.', function() {
             var expected_header = "EG1-HMAC-SHA256 client_token=akab-client-token-xxx-xxxxxxxxxxxxxxxx;access_token=akab-access-token-xxx-xxxxxxxxxxxxxxxx;timestamp=20140321T19:34:21+0000;nonce=nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;signature=6Q6PiTipLae6n4GsSIDTCJ54bEbHUBp+4MUXrbQCBoY=";

--- a/test/test_data.json
+++ b/test/test_data.json
@@ -39,6 +39,17 @@
         },
         "expectedAuthorization": "EG1-HMAC-SHA256 client_token=akab-client-token-xxx-xxxxxxxxxxxxxxxx;access_token=akab-access-token-xxx-xxxxxxxxxxxxxxxx;timestamp=20140321T19:34:21+0000;nonce=nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;signature=hXm4iCxtpN22m4cbZb4lVLW5rhX8Ca82vCFqXzSTPe4="
     }, {
+       "testName": "Post uses passed-max-body",
+       "request": {
+           "method": "POST",
+           "path": "/testapi/v1/t3",
+           "data": "datadatadatadatadatadatadatadata",
+           "headers": [{
+               "Host": "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net"
+           }]
+       },
+       "expectedAuthorization": "EG1-HMAC-SHA256 client_token=akab-client-token-xxx-xxxxxxxxxxxxxxxx;access_token=akab-access-token-xxx-xxxxxxxxxxxxxxxx;timestamp=20140321T19:34:21+0000;nonce=nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;signature=asJgKWm9tB/YhFByqnOtpcgvmzR+zpTGBgaSY/IhbNA="
+   }, {
         "testName": "POST too large",
         "request": {
             "method": "POST",


### PR DESCRIPTION
Akamai Forward rewrite Cloudlet api has a max-body size of 131072. The current node implementation uses a hard coded value of 2048. This change allows the value to come from the edgerc file or from the initialization of the EdgeGrid object in api.js.

The default value of 2048 is still used if a value is not passed during initialization.