### PR TITLE
Make auth() in api.js chainable

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -32,10 +32,10 @@ var EdgeGrid = function(client_token, client_secret, access_token, host, debug) 
 
 /**
  * Builds the request using the properties of the local config Object.
- * 
+ *
  * @param  {Object} req The request Object. Can optionally contain a
- *                      'headersToSign' property: An ordered list header names 
- *                      that will be included in the signature. This will be 
+ *                      'headersToSign' property: An ordered list header names
+ *                      that will be included in the signature. This will be
  *                      provided by specific APIs.
  */
 EdgeGrid.prototype.auth = function(req) {
@@ -63,6 +63,7 @@ EdgeGrid.prototype.auth = function(req) {
     this.config.access_token,
     this.config.host
   );
+  return this;
 };
 
 EdgeGrid.prototype.send = function(callback) {
@@ -78,6 +79,8 @@ EdgeGrid.prototype.send = function(callback) {
 
     callback(body, response);
   }.bind(this));
+
+  return this;
 };
 
 EdgeGrid.prototype._handleRedirect = function(resp, callback) {
@@ -93,11 +96,11 @@ EdgeGrid.prototype._handleRedirect = function(resp, callback) {
 
 /**
  * Creates a config object from a set of parameters.
- * 
+ *
  * @param {String} client_token    The client token
  * @param {String} client_secret   The client secret
  * @param {String} access_token    The access token
- * @param {String} host            The host 
+ * @param {String} host            The host
  */
 EdgeGrid.prototype._setConfigFromStrings = function(client_token, client_secret, access_token, host) {
   if (!validatedArgs([client_token, client_secret, access_token, host])) {
@@ -133,7 +136,7 @@ function validatedArgs(args) {
 
 /**
  * Creates a config     Object from the section of a defined .edgerc file.
- *     
+ *
  * @param {Object} obj  An Object containing a path and section property that
  *                      define the .edgerc section to use to create the Object.
  */

--- a/test/src/api_test.js
+++ b/test/src/api_test.js
@@ -143,6 +143,10 @@ describe('Api', function() {
   });
 
   describe('#auth', function() {
+    it('should be chainable', function(){
+      assert.deepEqual(this.api, this.api.auth({ path: '/foo' }));
+    });
+
     describe('when minimal request options are passed', function() {
       beforeEach(function() {
         this.api.auth({
@@ -207,6 +211,11 @@ describe('Api', function() {
   });
 
   describe('#send', function() {
+
+    it('should be chainable', function(){
+      assert.deepEqual(this.api, this.api.auth({ path: '/foo' }).send());
+    });
+
     describe('when authentication is done with a simple options object specifying only a path', function() {
       beforeEach(function() {
         nock('https://base.com')


### PR DESCRIPTION
Fixes #18 by adding chaining back to "public" api methods.