### PR TITLE
Updates requests to 2.74.0 to skip vulnerability issues

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.7.0
+ignore: {}
+patch: {}

--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.7.0
-ignore: {}
-patch: {}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "log4js": "^0.6.14",
     "moment": "^2.7.0",
-    "request": "2.68.0",
+    "request": "2.74.0",
     "uuid": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "log4js": "^0.6.14",
     "moment": "^2.7.0",
-    "request": "2.60.0",
+    "request": "2.68.0",
     "uuid": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`requests` dependency has a vulnerability for versions `<2.60.0` and `>2.2.5`

This PR bumps the bundle up a minor version to `2.74.0`

For issues with `requests@2.6.0`  => [link](https://snyk.io/vuln/npm:request:20160119)
Why choose `requests@2.7.4` => [link](https://snyk.io/vuln/npm:tough-cookie:20160722)
